### PR TITLE
Fix BuildVariables method in SqlPackageRunner

### DIFF
--- a/src/Cake.SqlPackage/SqlPackageRunner.cs
+++ b/src/Cake.SqlPackage/SqlPackageRunner.cs
@@ -106,7 +106,7 @@ namespace Cake.SqlPackage
             {
                 foreach (var variable in settings.Variables)
                 {
-                    builder.Append($"/p:{variable.Key}={variable.Value}");
+                    builder.Append($"/v:{variable.Key}={variable.Value}");
                 }
             }
 

--- a/test/Cake.SqlPackage.UnitTests/DeployReport/SqlPackageDeployReportRunnerTests.cs
+++ b/test/Cake.SqlPackage.UnitTests/DeployReport/SqlPackageDeployReportRunnerTests.cs
@@ -457,7 +457,7 @@ namespace Cake.SqlPackage.UnitTests
                 var result = fixture.Run();
 
                 //Then
-                Assert.Equal($"/Action:DeployReport /p:{key}={value}", result.Args);
+                Assert.Equal($"/Action:DeployReport /v:{key}={value}", result.Args);
             }
 
             [Fact]
@@ -472,7 +472,7 @@ namespace Cake.SqlPackage.UnitTests
                 var result = fixture.Run();
 
                 //Then
-                Assert.Equal($"/Action:DeployReport /OverwriteFiles:True /p:CommandTimeout=120", result.Args);
+                Assert.Equal($"/Action:DeployReport /OverwriteFiles:True /v:CommandTimeout=120", result.Args);
             }
         }
     }

--- a/test/Cake.SqlPackage.UnitTests/Publish/SqlPackagePublishRunnerTests.cs
+++ b/test/Cake.SqlPackage.UnitTests/Publish/SqlPackagePublishRunnerTests.cs
@@ -485,7 +485,7 @@ namespace Cake.SqlPackage.UnitTests
                 var result = fixture.Run();
 
                 //Then
-                Assert.Equal($"/Action:Publish /p:{key}={value}", result.Args);
+                Assert.Equal($"/Action:Publish /v:{key}={value}", result.Args);
             }
 
             [Fact]
@@ -500,7 +500,7 @@ namespace Cake.SqlPackage.UnitTests
                 var result = fixture.Run();
 
                 //Then
-                Assert.Equal($"/Action:Publish /OverwriteFiles:True /p:CommandTimeout=120", result.Args);
+                Assert.Equal($"/Action:Publish /OverwriteFiles:True /v:CommandTimeout=120", result.Args);
             }
         }
     }

--- a/test/Cake.SqlPackage.UnitTests/Script/SqlPackageScriptRunnerTests.cs
+++ b/test/Cake.SqlPackage.UnitTests/Script/SqlPackageScriptRunnerTests.cs
@@ -457,7 +457,7 @@ namespace Cake.SqlPackage.UnitTests
                 var result = fixture.Run();
 
                 //Then
-                Assert.Equal($"/Action:Script /p:{key}={value}", result.Args);
+                Assert.Equal($"/Action:Script /v:{key}={value}", result.Args);
             }
 
             [Fact]
@@ -472,7 +472,7 @@ namespace Cake.SqlPackage.UnitTests
                 var result = fixture.Run();
 
                 //Then
-                Assert.Equal($"/Action:Script /OverwriteFiles:True /p:CommandTimeout=120", result.Args);
+                Assert.Equal($"/Action:Script /OverwriteFiles:True /v:CommandTimeout=120", result.Args);
             }
         }
     }


### PR DESCRIPTION
https://msdn.microsoft.com/library/hh550080(vs.103).aspx#Anchor_7
According to this reference correct switch for variables is **v**