### PR TITLE
(GH-17) Expose ProcessSettings for SqlPackage to Cake alias methods

### DIFF
--- a/src/Cake.SqlPackage/DeployReport/SqlPackageDeployReportRunner.cs
+++ b/src/Cake.SqlPackage/DeployReport/SqlPackageDeployReportRunner.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Cake.Core;
+﻿using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
@@ -23,21 +22,7 @@ namespace Cake.SqlPackage
             Environment = environment;
         }
 
-        /// <summary>
-        /// Runs SqlPackage with the specified deployreport settings.
-        /// </summary>
-        /// <param name="settings">The settings.</param>
-        public void DeployReport(SqlPackageDeployReportSettings settings)
-        {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
-
-            Run(settings, BuildArguments(settings));
-        }
-
-        private ProcessArgumentBuilder BuildArguments(SqlPackageDeployReportSettings settings)
+        protected override ProcessArgumentBuilder BuildArguments(SqlPackageDeployReportSettings settings)
         {
             var builder = CreateBuilder(settings);
 

--- a/src/Cake.SqlPackage/DriftReport/SqlPackageDriftReportRunner.cs
+++ b/src/Cake.SqlPackage/DriftReport/SqlPackageDriftReportRunner.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Cake.Core;
+﻿using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
@@ -25,20 +24,7 @@ namespace Cake.SqlPackage
         {
         }
 
-        /// <summary>
-        /// Runs SqlPackage with the specified extract settings.
-        /// </summary>
-        public void DriftReport(SqlPackageDriftReportSettings settings)
-        {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
-
-            Run(settings, BuildArguments(settings));
-        }
-
-        private ProcessArgumentBuilder BuildArguments(SqlPackageDriftReportSettings settings)
+        protected override ProcessArgumentBuilder BuildArguments(SqlPackageDriftReportSettings settings)
         {
             var builder = CreateBuilder(settings);
 

--- a/src/Cake.SqlPackage/Export/SqlPackageExportRunner.cs
+++ b/src/Cake.SqlPackage/Export/SqlPackageExportRunner.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Cake.Core;
+﻿using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
@@ -25,21 +24,7 @@ namespace Cake.SqlPackage
         {
         }
 
-        /// <summary>
-        /// Runs SqlPackage with the specified extract settings.
-        /// </summary>
-        /// <param name="settings">The SQL package extract settings.</param>
-        public void Export(SqlPackageExportSettings settings)
-        {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
-
-            Run(settings, BuildArguments(settings));
-        }
-
-        private ProcessArgumentBuilder BuildArguments(SqlPackageExportSettings settings)
+        protected override ProcessArgumentBuilder BuildArguments(SqlPackageExportSettings settings)
         {
             var builder = CreateBuilder(settings);
 

--- a/src/Cake.SqlPackage/Extract/SqlPackageExtractRunner.cs
+++ b/src/Cake.SqlPackage/Extract/SqlPackageExtractRunner.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Cake.Core;
+﻿using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
@@ -25,21 +24,7 @@ namespace Cake.SqlPackage
         {
         }
 
-        /// <summary>
-        /// Runs SqlPackage with the specified extract settings.
-        /// </summary>
-        /// <param name="settings">The SQL package extract settings.</param>
-        public void Extract(SqlPackageExtractSettings settings)
-        {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
-
-            Run(settings, BuildArguments(settings));
-        }
-
-        private ProcessArgumentBuilder BuildArguments(SqlPackageExtractSettings settings)
+        protected override ProcessArgumentBuilder BuildArguments(SqlPackageExtractSettings settings)
         {
             var builder = CreateBuilder(settings);
 

--- a/src/Cake.SqlPackage/Import/SqlPackageImportRunner.cs
+++ b/src/Cake.SqlPackage/Import/SqlPackageImportRunner.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Cake.Core;
+﻿using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
@@ -25,21 +24,7 @@ namespace Cake.SqlPackage
         {
         }
 
-        /// <summary>
-        /// Runs SqlPackage with the specified extract settings.
-        /// </summary>
-        /// <param name="settings">The SQL package extract settings.</param>
-        public void Import(SqlPackageImportSettings settings)
-        {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
-
-            Run(settings, BuildArguments(settings));
-        }
-
-        private ProcessArgumentBuilder BuildArguments(SqlPackageImportSettings settings)
+        protected override ProcessArgumentBuilder BuildArguments(SqlPackageImportSettings settings)
         {
             var builder = CreateBuilder(settings);
 

--- a/src/Cake.SqlPackage/Publish/SqlPackagePublishRunner.cs
+++ b/src/Cake.SqlPackage/Publish/SqlPackagePublishRunner.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using Cake.Core;
+﻿using Cake.Core;
 using Cake.Core.IO;
 using Cake.Core.Tooling;
 
@@ -23,21 +22,7 @@ namespace Cake.SqlPackage
             Environment = environment;
         }
 
-        /// <summary>
-        /// Runs SqlPackage with the specified publish settings.
-        /// </summary>
-        /// <param name="settings">The settings.</param>
-        public void Publish(SqlPackagePublishSettings settings)
-        {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
-
-            Run(settings, BuildArguments(settings));
-        }
-
-        private ProcessArgumentBuilder BuildArguments(SqlPackagePublishSettings settings)
+        protected override ProcessArgumentBuilder BuildArguments(SqlPackagePublishSettings settings)
         {
             var builder = CreateBuilder(settings);
 

--- a/src/Cake.SqlPackage/Script/SqlPackageScriptRunner.cs
+++ b/src/Cake.SqlPackage/Script/SqlPackageScriptRunner.cs
@@ -23,21 +23,7 @@ namespace Cake.SqlPackage
             Environment = environment;
         }
 
-        /// <summary>
-        /// Runs SqlPackage with the specified publish settings.
-        /// </summary>
-        /// <param name="settings">The settings.</param>
-        public void Script(SqlPackageScriptSettings settings)
-        {
-            if (settings == null)
-            {
-                throw new ArgumentNullException(nameof(settings));
-            }
-
-            Run(settings, BuildArguments(settings));
-        }
-
-        private ProcessArgumentBuilder BuildArguments(SqlPackageScriptSettings settings)
+        protected override ProcessArgumentBuilder BuildArguments(SqlPackageScriptSettings settings)
         {
             var builder = CreateBuilder(settings);
 

--- a/src/Cake.SqlPackage/SqlPackageAliases.cs
+++ b/src/Cake.SqlPackage/SqlPackageAliases.cs
@@ -1,6 +1,7 @@
 ﻿using Cake.Core;
 using Cake.Core.Annotations;
 using System;
+using Cake.Core.IO;
 
 namespace Cake.SqlPackage
 {
@@ -32,13 +33,7 @@ namespace Cake.SqlPackage
         [CakeAliasCategory("Extract")]
         public static void SqlPackageExtract(this ICakeContext context, SqlPackageExtractSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var runner = new SqlPackageExtractRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Execute(settings ?? new SqlPackageExtractSettings());
+            SqlPackageExtract(context, settings, null);
         }
 
         /// <summary>
@@ -76,6 +71,33 @@ namespace Cake.SqlPackage
         }
 
         /// <summary>
+        /// Creates a database snapshot (.dacpac) file from SQL Server.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <param name="processSettings">The ProcessSettings for SqlPackage.</param>
+        /// <example>
+        ///   <code>
+        ///     var settings = new SqlPackageExtractSettings();
+        ///     var processSettings = new ProcessSettings();
+        ///
+        ///     SqlPackageExtract(settings, processSettings);
+        ///   </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Extract")]
+        public static void SqlPackageExtract(this ICakeContext context, SqlPackageExtractSettings settings, ProcessSettings processSettings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var runner = new SqlPackageExtractRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Execute(settings ?? new SqlPackageExtractSettings(), processSettings);
+        }
+
+        /// <summary>
         /// Incrementally updates a database schema to match the schema of a source .dacpac file.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -91,13 +113,7 @@ namespace Cake.SqlPackage
         [CakeAliasCategory("Publish")]
         public static void SqlPackagePublish(this ICakeContext context, SqlPackagePublishSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var runner = new SqlPackagePublishRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Execute(settings ?? new SqlPackagePublishSettings());
+            SqlPackagePublish(context, settings, null);
         }
 
         /// <summary>
@@ -136,6 +152,33 @@ namespace Cake.SqlPackage
         }
 
         /// <summary>
+        /// Incrementally updates a database schema to match the schema of a source .dacpac file.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <param name="processSettings">The ProcessSettings for SqlPackage</param>
+        /// <example>
+        ///   <code>
+        ///     var settings = new SqlPackagePublishSettings();
+        ///     var processSettings = new ProcessSettings();
+        ///
+        ///     SqlPackagePublish(settings, processSettings);
+        ///   </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Publish")]
+        public static void SqlPackagePublish(this ICakeContext context, SqlPackagePublishSettings settings, ProcessSettings processSettings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var runner = new SqlPackagePublishRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Execute(settings ?? new SqlPackagePublishSettings(), processSettings);
+        }
+
+        /// <summary>
         /// Exports a live database to a BACPAC package (.bacpac file).
         /// </summary>
         /// <param name="context">The context.</param>
@@ -156,13 +199,7 @@ namespace Cake.SqlPackage
         [CakeAliasCategory("Export")]
         public static void SqlPackageExport(this ICakeContext context, SqlPackageExportSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var runner = new SqlPackageExportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Execute(settings ?? new SqlPackageExportSettings());
+            SqlPackageExport(context, settings, null);
         }
 
         /// <summary>
@@ -202,6 +239,38 @@ namespace Cake.SqlPackage
         }
 
         /// <summary>
+        /// Exports a live database to a BACPAC package (.bacpac file).
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <param name="processSettings">The ProcessSettings for SqlPackage.</param>
+        /// <example>
+        ///   <code>
+        ///     var settings = new SqlPackageExportSettings
+        ///     {
+        ///         SourceConnectionString = connectionString,
+        ///         Profile = File("./profile.publish.xml")
+        ///         TargetFile = File("database.bacpac")
+        ///     };
+        ///     var processSettings = new ProcessSettings();
+        ///
+        ///     SqlPackageExport(settings, processSettings);
+        ///   </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Export")]
+        public static void SqlPackageExport(this ICakeContext context, SqlPackageExportSettings settings, ProcessSettings processSettings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var runner = new SqlPackageExportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Execute(settings ?? new SqlPackageExportSettings(), processSettings);
+        }
+
+        /// <summary>
         /// Imports the schema and table data from a BACPAC package into a new user database
         /// </summary>
         /// <param name="context">The context.</param>
@@ -221,13 +290,7 @@ namespace Cake.SqlPackage
         [CakeAliasCategory("Import")]
         public static void SqlPackageImport(this ICakeContext context, SqlPackageImportSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var runner = new SqlPackageImportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Execute(settings ?? new SqlPackageImportSettings());
+            SqlPackageImport(context, settings, null);
         }
 
         /// <summary>
@@ -266,6 +329,37 @@ namespace Cake.SqlPackage
         }
 
         /// <summary>
+        /// Imports the schema and table data from a BACPAC package into a new user database
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <param name="processSettings">The ProcessSettings for SqlPackage.</param>
+        /// <example>
+        ///   <code>
+        ///     var settings = new SqlPackageImportSettings
+        ///     {
+        ///         SourceFile = File("database.bacpac")
+        ///         TargetConnectionString = connectionString
+        ///     };
+        ///     var processSettings = new ProcessSettings();
+        ///
+        ///     SqlPackageImport(settings, processSettings);
+        ///   </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Import")]
+        public static void SqlPackageImport(this ICakeContext context, SqlPackageImportSettings settings, ProcessSettings processSettings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var runner = new SqlPackageImportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Execute(settings ?? new SqlPackageImportSettings(), processSettings);
+        }
+
+        /// <summary>
         /// Creates an XML report of the changes that would be made by a publish action.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -281,13 +375,7 @@ namespace Cake.SqlPackage
         [CakeAliasCategory("DeployReport")]
         public static void SqlPackageDeployReport(this ICakeContext context, SqlPackageDeployReportSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var runner = new SqlPackageDeployReportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Execute(settings ?? new SqlPackageDeployReportSettings());
+            SqlPackageDeployReport(context, settings, null);
         }
 
         /// <summary>
@@ -325,6 +413,33 @@ namespace Cake.SqlPackage
         }
 
         /// <summary>
+        /// Creates an XML report of the changes that would be made by a publish action.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <param name="processSettings">The ProcessSettings for SqlPackage.</param>
+        /// <example>
+        ///   <code>
+        ///     var settings = new SqlPackageDeployReportSettings();
+        ///     var processSettings = new ProcessSettings();
+        ///
+        ///     SqlPackageDeployReport(settings, processSettings);
+        ///   </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("DeployReport")]
+        public static void SqlPackageDeployReport(this ICakeContext context, SqlPackageDeployReportSettings settings, ProcessSettings processSettings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var runner = new SqlPackageDeployReportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Execute(settings ?? new SqlPackageDeployReportSettings(), processSettings);
+        }
+
+        /// <summary>
         /// Creates an XML report of the changes that have been made to a registered database since it was last registered.
         /// </summary>
         /// <param name="context">The context.</param>
@@ -340,13 +455,7 @@ namespace Cake.SqlPackage
         [CakeAliasCategory("DriftReport")]
         public static void SqlPackageDriftReport(this ICakeContext context, SqlPackageDriftReportSettings settings)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
-
-            var runner = new SqlPackageDriftReportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Execute(settings ?? new SqlPackageDriftReportSettings());
+            SqlPackageDriftReport(context, settings, null);
         }
 
         /// <summary>
@@ -384,31 +493,55 @@ namespace Cake.SqlPackage
         }
 
         /// <summary>
-        /// Creates a Transact-SQL incremental update script that updates the schema of a target to match the schema of a source.
+        /// Creates an XML report of the changes that have been made to a registered database since it was last registered.
         /// </summary>
         /// <param name="context">The context.</param>
         /// <param name="settings">The settings.</param>
+        /// <param name="processSettings">The ProcessSettings for SqlPackage.</param>
         /// <example>
         ///   <code>
-        ///     SqlPackageScript(settings =>
-        ///     {
-        ///        settings.SourceFile = File("./CoffeeHouse/bin/" + configuration + "/CoffeeHouse.dacpac");
-        ///        settings.Profile = File("./CoffeeHouse/publish/CoffeeHouse.publish.xml");
-        ///        settings.OutputPath = File("./scripts/CoffeeHouse.sql");
-        ///     });
+        ///     var settings = new SqlPackageDriftReportSettings();
+        ///     var processSettings = new ProcessSettings();
+        ///
+        ///     SqlPackageDriftReport(settings, processSettings);
         ///   </code>
         /// </example>
         [CakeMethodAlias]
-        [CakeAliasCategory("Script")]
-        public static void SqlPackageScript(this ICakeContext context, SqlPackageScriptSettings settings)
+        [CakeAliasCategory("DriftReport")]
+        public static void SqlPackageDriftReport(this ICakeContext context, SqlPackageDriftReportSettings settings, ProcessSettings processSettings)
         {
             if (context == null)
             {
                 throw new ArgumentNullException(nameof(context));
             }
 
-            var runner = new SqlPackageScriptRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Execute(settings ?? new SqlPackageScriptSettings());
+            var runner = new SqlPackageDriftReportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Execute(settings ?? new SqlPackageDriftReportSettings(), processSettings);
+        }
+
+
+        /// <summary>
+        /// Creates a Transact-SQL incremental update script that updates the schema of a target to match the schema of a source.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <example>
+        ///   <code>
+        ///     var settings = new SqlPackageScriptSettings
+        ///     {
+        ///        SourceFile = File("./CoffeeHouse/bin/" + configuration + "/CoffeeHouse.dacpac");
+        ///        Profile = File("./CoffeeHouse/publish/CoffeeHouse.publish.xml");
+        ///        OutputPath = File("./scripts/CoffeeHouse.sql");
+        ///     }
+        ///
+        ///     SqlPackageScript(settings);
+        ///   </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Script")]
+        public static void SqlPackageScript(this ICakeContext context, SqlPackageScriptSettings settings)
+        {
+            SqlPackageScript(context, settings, null);
         }
 
         /// <summary>
@@ -445,6 +578,38 @@ namespace Cake.SqlPackage
 
             var runner = new SqlPackageScriptRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
             runner.Execute(settings);
+        }
+
+        /// <summary>
+        /// Creates a Transact-SQL incremental update script that updates the schema of a target to match the schema of a source.
+        /// </summary>
+        /// <param name="context">The context.</param>
+        /// <param name="settings">The settings.</param>
+        /// <param name="processSettings">The ProcessSettings for SqlPackage.</param>
+        /// <example>
+        ///   <code>
+        ///     var settings = new SqlPackageScriptSettings
+        ///     {
+        ///        SourceFile = File("./CoffeeHouse/bin/" + configuration + "/CoffeeHouse.dacpac");
+        ///        Profile = File("./CoffeeHouse/publish/CoffeeHouse.publish.xml");
+        ///        OutputPath = File("./scripts/CoffeeHouse.sql");
+        ///     }
+        ///     var processSettings = new ProcessSettings();
+        ///
+        ///     SqlPackageScript(settings, processSettings);
+        ///   </code>
+        /// </example>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Script")]
+        public static void SqlPackageScript(this ICakeContext context, SqlPackageScriptSettings settings, ProcessSettings processSettings)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            var runner = new SqlPackageScriptRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
+            runner.Execute(settings ?? new SqlPackageScriptSettings(), processSettings);
         }
     }
 }

--- a/src/Cake.SqlPackage/SqlPackageAliases.cs
+++ b/src/Cake.SqlPackage/SqlPackageAliases.cs
@@ -38,7 +38,7 @@ namespace Cake.SqlPackage
             }
 
             var runner = new SqlPackageExtractRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Extract(settings ?? new SqlPackageExtractSettings());
+            runner.Execute(settings ?? new SqlPackageExtractSettings());
         }
 
         /// <summary>
@@ -72,7 +72,7 @@ namespace Cake.SqlPackage
             configurationAction(settings);
 
             var runner = new SqlPackageExtractRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Extract(settings);
+            runner.Execute(settings);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Cake.SqlPackage
             }
 
             var runner = new SqlPackagePublishRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Publish(settings ?? new SqlPackagePublishSettings());
+            runner.Execute(settings ?? new SqlPackagePublishSettings());
         }
 
         /// <summary>
@@ -132,7 +132,7 @@ namespace Cake.SqlPackage
             configurationAction(settings);
 
             var runner = new SqlPackagePublishRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Publish(settings);
+            runner.Execute(settings);
         }
 
         /// <summary>
@@ -162,7 +162,7 @@ namespace Cake.SqlPackage
             }
 
             var runner = new SqlPackageExportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Export(settings ?? new SqlPackageExportSettings());
+            runner.Execute(settings ?? new SqlPackageExportSettings());
         }
 
         /// <summary>
@@ -198,7 +198,7 @@ namespace Cake.SqlPackage
             configurationAction(settings);
 
             var runner = new SqlPackageExportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Export(settings);
+            runner.Execute(settings);
         }
 
         /// <summary>
@@ -227,7 +227,7 @@ namespace Cake.SqlPackage
             }
 
             var runner = new SqlPackageImportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Import(settings ?? new SqlPackageImportSettings());
+            runner.Execute(settings ?? new SqlPackageImportSettings());
         }
 
         /// <summary>
@@ -262,7 +262,7 @@ namespace Cake.SqlPackage
             configurationAction(settings);
 
             var runner = new SqlPackageImportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Import(settings);
+            runner.Execute(settings);
         }
 
         /// <summary>
@@ -287,7 +287,7 @@ namespace Cake.SqlPackage
             }
 
             var runner = new SqlPackageDeployReportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.DeployReport(settings ?? new SqlPackageDeployReportSettings());
+            runner.Execute(settings ?? new SqlPackageDeployReportSettings());
         }
 
         /// <summary>
@@ -321,7 +321,7 @@ namespace Cake.SqlPackage
             configurationAction(settings);
 
             var runner = new SqlPackageDeployReportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.DeployReport(settings);
+            runner.Execute(settings);
         }
 
         /// <summary>
@@ -346,7 +346,7 @@ namespace Cake.SqlPackage
             }
 
             var runner = new SqlPackageDriftReportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.DriftReport(settings ?? new SqlPackageDriftReportSettings());
+            runner.Execute(settings ?? new SqlPackageDriftReportSettings());
         }
 
         /// <summary>
@@ -380,7 +380,7 @@ namespace Cake.SqlPackage
             configurationAction(settings);
 
             var runner = new SqlPackageDriftReportRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.DriftReport(settings);
+            runner.Execute(settings);
         }
 
         /// <summary>
@@ -408,7 +408,7 @@ namespace Cake.SqlPackage
             }
 
             var runner = new SqlPackageScriptRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Script(settings ?? new SqlPackageScriptSettings());
+            runner.Execute(settings ?? new SqlPackageScriptSettings());
         }
 
         /// <summary>
@@ -444,7 +444,7 @@ namespace Cake.SqlPackage
             configurationAction(settings);
 
             var runner = new SqlPackageScriptRunner(context.FileSystem, context.Environment, context.ProcessRunner, context.Tools);
-            runner.Script(settings);
+            runner.Execute(settings);
         }
     }
 }

--- a/src/Cake.SqlPackage/SqlPackageRunner.cs
+++ b/src/Cake.SqlPackage/SqlPackageRunner.cs
@@ -20,19 +20,20 @@ namespace Cake.SqlPackage
         /// The Cake environment in context.
         /// </summary>
         public ICakeEnvironment Environment { get; set; }
-        
+
         /// <summary>
         /// Runs SqlPackage with the specified settings.
         /// </summary>
         /// <param name="settings">The settings.</param>
-        public void Execute(T settings)
+        /// <param name="processSettings">The ProcessSettings for SqlPackage.</param>
+        public void Execute(T settings, ProcessSettings processSettings = null)
         {
             if (settings == null)
             {
                 throw new ArgumentNullException(nameof(settings));
             }
 
-            Run(settings, BuildArguments(settings));
+            Run(settings, BuildArguments(settings), processSettings, null);
         }
 
         protected abstract ProcessArgumentBuilder BuildArguments(T settings);

--- a/src/Cake.SqlPackage/SqlPackageRunner.cs
+++ b/src/Cake.SqlPackage/SqlPackageRunner.cs
@@ -20,6 +20,22 @@ namespace Cake.SqlPackage
         /// The Cake environment in context.
         /// </summary>
         public ICakeEnvironment Environment { get; set; }
+        
+        /// <summary>
+        /// Runs SqlPackage with the specified settings.
+        /// </summary>
+        /// <param name="settings">The settings.</param>
+        public void Execute(T settings)
+        {
+            if (settings == null)
+            {
+                throw new ArgumentNullException(nameof(settings));
+            }
+
+            Run(settings, BuildArguments(settings));
+        }
+
+        protected abstract ProcessArgumentBuilder BuildArguments(T settings);
 
         /// <summary>
         /// Builds the common SqlPackage arguments.

--- a/test/Cake.SqlPackage.UnitTests/DeployReport/SqlPackageDeployReportFixture.cs
+++ b/test/Cake.SqlPackage.UnitTests/DeployReport/SqlPackageDeployReportFixture.cs
@@ -3,16 +3,13 @@
     internal sealed class SqlPackageDeployReportFixture : PackageFixture<SqlPackageDeployReportSettings>
     {
         public SqlPackageDeployReportFixture()
-            : base("SqlPackage.exe")
         {
             Settings.WorkingDirectory = "/Working";
         }
 
-        /// <summary>Runs the tool.</summary>
-        protected override void RunTool()
+        protected override SqlPackageRunner<SqlPackageDeployReportSettings> CreateTool()
         {
-            var tool = new SqlPackageDeployReportRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Execute(Settings);
+            return new SqlPackageDeployReportRunner(FileSystem, Environment, ProcessRunner, Tools);
         }
     }
 }

--- a/test/Cake.SqlPackage.UnitTests/DeployReport/SqlPackageDeployReportFixture.cs
+++ b/test/Cake.SqlPackage.UnitTests/DeployReport/SqlPackageDeployReportFixture.cs
@@ -12,7 +12,7 @@
         protected override void RunTool()
         {
             var tool = new SqlPackageDeployReportRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.DeployReport(Settings);
+            tool.Execute(Settings);
         }
     }
 }

--- a/test/Cake.SqlPackage.UnitTests/DeployReport/SqlPackageDeployReportRunnerTests.cs
+++ b/test/Cake.SqlPackage.UnitTests/DeployReport/SqlPackageDeployReportRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Core;
+using Cake.Core.IO;
 using Cake.Testing;
 using Xunit;
 
@@ -9,11 +10,17 @@ namespace Cake.SqlPackage.UnitTests
     {
         public sealed class TheRunMethod
         {
+            private SqlPackageDeployReportFixture fixture;
+
+            public TheRunMethod()
+            {
+                fixture = new SqlPackageDeployReportFixture();
+            }
+
             [Fact]
             public void Should_Throw_If_Settings_Is_Null()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings = null;
 
                 // When
@@ -27,7 +34,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Sql_Package_Runner_Was_Not_Found()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.GivenDefaultToolDoNotExist();
 
                 // When
@@ -44,7 +50,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Use_Sql_Package_Runner_From_Tool_Path_If_Provided(string toolPath, string expected)
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.ToolPath = toolPath;
                 fixture.GivenSettingsToolPathExist();
 
@@ -58,9 +63,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Find_Sql_Package_Runner_If_Tool_Path_Not_Provided()
             {
-                // Given
-                var fixture = new SqlPackageDeployReportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -71,9 +73,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Set_Working_Directory()
             {
-                // Given
-                var fixture = new SqlPackageDeployReportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -85,7 +84,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Process_Was_Not_Started()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.GivenProcessCannotStart();
 
                 // When
@@ -100,7 +98,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.GivenProcessExitsWithCode(1);
 
                 // When
@@ -114,9 +111,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Add_Action_If_Provided()
             {
-                // Given
-                var fixture = new SqlPackageDeployReportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -128,7 +122,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_OutputPath_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.OutputPath = "./artifacts";
 
                 // When
@@ -142,7 +135,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Overwrite_Files_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.OverwriteFiles = true;
 
                 // When
@@ -156,7 +148,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Profile_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.Profile = "./profile.pubxml";
 
                 // When
@@ -170,7 +161,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Quiet_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.Quiet = true;
 
                 // When
@@ -183,9 +173,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Not_Add_Quiet_If_Not_Provided()
             {
-                // Given
-                var fixture = new SqlPackageDeployReportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -197,7 +184,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Source_Connection_String_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -212,7 +198,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_File_If_Source_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -227,7 +212,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Properties_If_Source_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -249,7 +233,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Source_File_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.SourceFile = "./sqlDeployReportprofile.pubxml";
 
                 // When
@@ -263,7 +246,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Connection_If_Source_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.SourceFile = "./sqlDeployReportprofile.pubxml";
 
                 // When
@@ -277,7 +259,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Properties_If_Source_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.SourceFile = "./sqlDeployReportprofile.pubxml";
 
                 // When
@@ -298,7 +279,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Target_Connection_String_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -313,7 +293,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_File_If_Target_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -328,7 +307,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Properties_If_Target_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -350,7 +328,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Target_File_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.TargetFile = "./sqlDeployReportprofile.pubxml";
 
                 // When
@@ -364,7 +341,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Connection_If_Target_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.TargetFile = "./sqlDeployReportprofile.pubxml";
 
                 // When
@@ -378,7 +354,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Properties_If_Target_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.TargetFile = "./sqlDeployReportprofile.pubxml";
 
                 // When
@@ -395,20 +370,6 @@ namespace Cake.SqlPackage.UnitTests
                 Assert.DoesNotContain("/TargetUser:", result.Args);
             }
 
-            [Fact]
-            public void Should_Add_Tenant_Id_Provided()
-            {
-                // Given
-                var fixture = new SqlPackageExportFixture();
-                fixture.Settings.TenantId = "10";
-
-                // When
-                var result = fixture.Run();
-
-                // Then
-                Assert.Equal("/Action:Export /TenantId:10", result.Args);
-            }
-
             [Theory]
             [InlineData("CommandTimeout", "120")]
             [InlineData("CreateNewDatabase", "True")]
@@ -417,7 +378,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Properties_If_Provided(string key, string value)
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.Properties.Add(key, value);
 
                 // When
@@ -431,7 +391,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Properties_After_Settings_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.OverwriteFiles = true;
                 fixture.Settings.Properties.Add("CommandTimeout", "120");
 
@@ -450,7 +409,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Variables_If_Provided(string key, string value)
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.Variables.Add(key, value);
 
                 // When
@@ -464,7 +422,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Variables_After_Settings_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDeployReportFixture();
                 fixture.Settings.OverwriteFiles = true;
                 fixture.Settings.Variables.Add("CommandTimeout", "120");
 
@@ -473,6 +430,19 @@ namespace Cake.SqlPackage.UnitTests
 
                 //Then
                 Assert.Equal($"/Action:DeployReport /OverwriteFiles:True /v:CommandTimeout=120", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Process_Settings_If_Provided()
+            {
+                // Given
+                fixture.ProcessSettings = new ProcessSettings {RedirectStandardOutput = true};
+
+                // When
+                var result = fixture.Run();
+
+                //Then
+                Assert.Equal(fixture.ProcessSettings, result.Process);
             }
         }
     }

--- a/test/Cake.SqlPackage.UnitTests/DriftReport/SqlPackageDriftReportFixture.cs
+++ b/test/Cake.SqlPackage.UnitTests/DriftReport/SqlPackageDriftReportFixture.cs
@@ -11,7 +11,7 @@
         protected override void RunTool()
         {
             var tool = new SqlPackageDriftReportRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.DriftReport(Settings);
+            tool.Execute(Settings);
         }
     }
 }

--- a/test/Cake.SqlPackage.UnitTests/DriftReport/SqlPackageDriftReportFixture.cs
+++ b/test/Cake.SqlPackage.UnitTests/DriftReport/SqlPackageDriftReportFixture.cs
@@ -3,15 +3,13 @@
     internal sealed class SqlPackageDriftReportFixture : PackageFixture<SqlPackageDriftReportSettings>
     {
         public SqlPackageDriftReportFixture()
-            : base("SqlPackage.exe")
         {
             Settings.WorkingDirectory = "/Working";
         }
 
-        protected override void RunTool()
+        protected override SqlPackageRunner<SqlPackageDriftReportSettings> CreateTool()
         {
-            var tool = new SqlPackageDriftReportRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Execute(Settings);
+            return new SqlPackageDriftReportRunner(FileSystem, Environment, ProcessRunner, Tools);
         }
     }
 }

--- a/test/Cake.SqlPackage.UnitTests/DriftReport/SqlPackageDriftReportRunnerTests.cs
+++ b/test/Cake.SqlPackage.UnitTests/DriftReport/SqlPackageDriftReportRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Core;
+using Cake.Core.IO;
 using Cake.Testing;
 using Xunit;
 
@@ -9,11 +10,17 @@ namespace Cake.SqlPackage.UnitTests
     {
         public sealed class TheRunMethod
         {
+            private SqlPackageDriftReportFixture fixture;
+
+            public TheRunMethod()
+            {
+                fixture = new SqlPackageDriftReportFixture();
+            }
+
             [Fact]
             public void Should_Throw_If_Settings_Is_Null()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings = null;
 
                 // When
@@ -27,7 +34,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Sql_Package_Runner_Was_Not_Found()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.GivenDefaultToolDoNotExist();
 
                 // When
@@ -44,7 +50,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Use_Sql_Package_Runner_From_Tool_Path_If_Provided(string toolPath, string expected)
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.ToolPath = toolPath;
                 fixture.GivenSettingsToolPathExist();
 
@@ -58,9 +63,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Find_Sql_Package_Runner_If_Tool_Path_Not_Provided()
             {
-                // Given
-                var fixture = new SqlPackageDriftReportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -71,9 +73,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Set_Working_Directory()
             {
-                // Given
-                var fixture = new SqlPackageDriftReportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -85,7 +84,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Process_Was_Not_Started()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.GivenProcessCannotStart();
 
                 // When
@@ -100,7 +98,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.GivenProcessExitsWithCode(1);
 
                 // When
@@ -114,9 +111,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Add_Action_If_Provided()
             {
-                // Given
-                var fixture = new SqlPackageDriftReportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -128,7 +122,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_OutputPath_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.OutputPath = "./artifacts";
 
                 // When
@@ -142,7 +135,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Overwrite_Files_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.OverwriteFiles = true;
 
                 // When
@@ -156,7 +148,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Profile_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.Profile = "./profile.pubxml";
 
                 // When
@@ -170,7 +161,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Quiet_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.Quiet = true;
 
                 // When
@@ -183,9 +173,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Not_Add_Quiet_If_Not_Provided()
             {
-                // Given
-                var fixture = new SqlPackageDriftReportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -197,7 +184,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Connection_String_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -212,7 +198,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_File()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.SourceFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -226,7 +211,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Properties_If_Source_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -248,7 +232,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_File_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.SourceFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -262,7 +245,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Properties_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -284,7 +266,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Target_Connection_String_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -299,7 +280,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_File_If_Target_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -314,7 +294,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Properties_If_Target_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -336,7 +315,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_File_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -350,7 +328,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Connection_If_Target_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -364,7 +341,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Tenant_Id_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.TenantId = "10";
 
                 // When
@@ -378,7 +354,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Universal_Authentication_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.UniversalAuthentication = true;
 
                 // When
@@ -392,7 +367,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Properties_If_Target_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -417,7 +391,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Properties_If_Provided(string key, string value)
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.Properties.Add(key, value);
 
                 // When
@@ -431,7 +404,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Properties_After_Settings_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageDriftReportFixture();
                 fixture.Settings.UniversalAuthentication = true;
                 fixture.Settings.Properties.Add("CommandTimeout", "120");
 
@@ -440,6 +412,19 @@ namespace Cake.SqlPackage.UnitTests
 
                 //Then
                 Assert.Equal($"/Action:DriftReport /UniversalAuthentication:True /p:CommandTimeout=120", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Process_Settings_If_Provided()
+            {
+                // Given
+                fixture.ProcessSettings = new ProcessSettings {RedirectStandardOutput = true};
+
+                // When
+                var result = fixture.Run();
+
+                //Then
+                Assert.Equal(fixture.ProcessSettings, result.Process);
             }
         }
     }

--- a/test/Cake.SqlPackage.UnitTests/Export/SqlPackageExportFixture.cs
+++ b/test/Cake.SqlPackage.UnitTests/Export/SqlPackageExportFixture.cs
@@ -11,7 +11,7 @@
         protected override void RunTool()
         {
             var tool = new SqlPackageExportRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Export(Settings);
+            tool.Execute(Settings);
         }
     }
 }

--- a/test/Cake.SqlPackage.UnitTests/Export/SqlPackageExportFixture.cs
+++ b/test/Cake.SqlPackage.UnitTests/Export/SqlPackageExportFixture.cs
@@ -3,15 +3,13 @@
     internal sealed class SqlPackageExportFixture : PackageFixture<SqlPackageExportSettings>
     {
         public SqlPackageExportFixture()
-            : base("SqlPackage.exe")
         {
             Settings.WorkingDirectory = "/Working";
         }
 
-        protected override void RunTool()
+        protected override SqlPackageRunner<SqlPackageExportSettings> CreateTool()
         {
-            var tool = new SqlPackageExportRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Execute(Settings);
+            return new SqlPackageExportRunner(FileSystem, Environment, ProcessRunner, Tools);
         }
     }
 }

--- a/test/Cake.SqlPackage.UnitTests/Export/SqlPackageExportRunnerTests.cs
+++ b/test/Cake.SqlPackage.UnitTests/Export/SqlPackageExportRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Core;
+using Cake.Core.IO;
 using Cake.Testing;
 using Xunit;
 
@@ -9,11 +10,17 @@ namespace Cake.SqlPackage.UnitTests
     {
         public sealed class TheRunMethod
         {
+            private SqlPackageExportFixture fixture;
+
+            public TheRunMethod()
+            {
+                fixture = new SqlPackageExportFixture();
+            }
+
             [Fact]
             public void Should_Throw_If_Settings_Is_Null()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings = null;
 
                 // When
@@ -27,7 +34,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Sql_Package_Runner_Was_Not_Found()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.GivenDefaultToolDoNotExist();
 
                 // When
@@ -44,7 +50,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Use_Sql_Package_Runner_From_Tool_Path_If_Provided(string toolPath, string expected)
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.ToolPath = toolPath;
                 fixture.GivenSettingsToolPathExist();
 
@@ -58,9 +63,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Find_Sql_Package_Runner_If_Tool_Path_Not_Provided()
             {
-                // Given
-                var fixture = new SqlPackageExportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -71,9 +73,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Set_Working_Directory()
             {
-                // Given
-                var fixture = new SqlPackageExportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -85,7 +84,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Process_Was_Not_Started()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.GivenProcessCannotStart();
 
                 // When
@@ -100,7 +98,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.GivenProcessExitsWithCode(1);
 
                 // When
@@ -114,9 +111,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Add_Action_If_Provided()
             {
-                // Given
-                var fixture = new SqlPackageExportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -128,7 +122,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_OutputPath_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.OutputPath = "./artifacts";
 
                 // When
@@ -142,7 +135,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Overwrite_Files_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.OverwriteFiles = true;
 
                 // When
@@ -156,7 +148,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Profile_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.Profile = "./profile.pubxml";
 
                 // When
@@ -170,7 +161,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Quiet_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.Quiet = true;
 
                 // When
@@ -183,9 +173,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Not_Add_Quiet_If_Not_Provided()
             {
-                // Given
-                var fixture = new SqlPackageExportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -196,9 +183,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Not_Add_Client_Id_If_Provided()
             {
-                // Given
-                var fixture = new SqlPackageExportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -210,7 +194,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Source_Connection_String_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -225,7 +208,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_File_If_Source_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -240,7 +222,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Properties_If_Source_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -262,7 +243,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_File_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.SourceFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -276,7 +256,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Connection_If_Source_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.SourceFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -290,7 +269,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Properties_If_Source_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.SourceFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -311,7 +289,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Connection_String_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -326,7 +303,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Target_File_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -340,7 +316,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Tenant_Id_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.TenantId = "10";
 
                 // When
@@ -348,20 +323,6 @@ namespace Cake.SqlPackage.UnitTests
 
                 // Then
                 Assert.Equal("/Action:Export /TenantId:10", result.Args);
-            }
-
-            [Fact]
-            public void Should_Add_Universal_Authentication_Provided()
-            {
-                // Given
-                var fixture = new SqlPackageImportFixture();
-                fixture.Settings.UniversalAuthentication = true;
-
-                // When
-                var result = fixture.Run();
-
-                // Then
-                Assert.Equal("/Action:Import /UniversalAuthentication:True", result.Args);
             }
 
             [Theory]
@@ -372,7 +333,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Properties_If_Provided(string key, string value)
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.Properties.Add(key, value);
 
                 // When
@@ -386,7 +346,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Properties_After_Settings_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExportFixture();
                 fixture.Settings.UniversalAuthentication = true;
                 fixture.Settings.Properties.Add("CommandTimeout", "120");
 
@@ -395,6 +354,19 @@ namespace Cake.SqlPackage.UnitTests
 
                 //Then
                 Assert.Equal($"/Action:Export /UniversalAuthentication:True /p:CommandTimeout=120", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Process_Settings_If_Provided()
+            {
+                // Given
+                fixture.ProcessSettings = new ProcessSettings {RedirectStandardOutput = true};
+
+                // When
+                var result = fixture.Run();
+
+                //Then
+                Assert.Equal(fixture.ProcessSettings, result.Process);
             }
         }
     }

--- a/test/Cake.SqlPackage.UnitTests/Extract/SqlPackageExtractFixture.cs
+++ b/test/Cake.SqlPackage.UnitTests/Extract/SqlPackageExtractFixture.cs
@@ -11,7 +11,7 @@
         protected override void RunTool()
         {
             var tool = new SqlPackageExtractRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Extract(Settings);
+            tool.Execute(Settings);
         }
     }
 }

--- a/test/Cake.SqlPackage.UnitTests/Extract/SqlPackageExtractFixture.cs
+++ b/test/Cake.SqlPackage.UnitTests/Extract/SqlPackageExtractFixture.cs
@@ -3,15 +3,13 @@
     internal sealed class SqlPackageExtractFixture : PackageFixture<SqlPackageExtractSettings>
     {
         public SqlPackageExtractFixture()
-            : base("SqlPackage.exe")
         {
             Settings.WorkingDirectory = "/Working";
         }
 
-        protected override void RunTool()
+        protected override SqlPackageRunner<SqlPackageExtractSettings> CreateTool()
         {
-            var tool = new SqlPackageExtractRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Execute(Settings);
+            return new SqlPackageExtractRunner(FileSystem, Environment, ProcessRunner, Tools);
         }
     }
 }

--- a/test/Cake.SqlPackage.UnitTests/Extract/SqlPackageExtractRunnerTests.cs
+++ b/test/Cake.SqlPackage.UnitTests/Extract/SqlPackageExtractRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Core;
+using Cake.Core.IO;
 using Cake.Testing;
 using Xunit;
 
@@ -9,11 +10,17 @@ namespace Cake.SqlPackage.UnitTests
     {
         public sealed class TheRunMethod
         {
+            private SqlPackageExtractFixture fixture;
+
+            public TheRunMethod()
+            {
+                fixture = new SqlPackageExtractFixture();
+            }
+
             [Fact]
             public void Should_Throw_If_Settings_Is_Null()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings = null;
 
                 // When
@@ -27,7 +34,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Sql_Package_Runner_Was_Not_Found()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.GivenDefaultToolDoNotExist();
 
                 // When
@@ -44,7 +50,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Use_Sql_Package_Runner_From_Tool_Path_If_Provided(string toolPath, string expected)
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.ToolPath = toolPath;
                 fixture.GivenSettingsToolPathExist();
 
@@ -58,9 +63,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Find_Sql_Package_Runner_If_Tool_Path_Not_Provided()
             {
-                // Given
-                var fixture = new SqlPackageExtractFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -71,9 +73,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Set_Working_Directory()
             {
-                // Given
-                var fixture = new SqlPackageExtractFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -85,7 +84,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Process_Was_Not_Started()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.GivenProcessCannotStart();
 
                 // When
@@ -100,7 +98,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.GivenProcessExitsWithCode(1);
 
                 // When
@@ -114,9 +111,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Add_Action_If_Provided()
             {
-                // Given
-                var fixture = new SqlPackageExtractFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -128,7 +122,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_OutputPath_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.OutputPath = "./artifacts";
 
                 // When
@@ -142,7 +135,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Overwrite_Files_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.OverwriteFiles = true;
 
                 // When
@@ -156,7 +148,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Profile_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.Profile = "./profile.pubxml";
 
                 // When
@@ -170,7 +161,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Quiet_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.Quiet = true;
 
                 // When
@@ -181,25 +171,8 @@ namespace Cake.SqlPackage.UnitTests
             }
 
             [Fact]
-            public void Should_Add_Azure_Key_Vault_Auth_Method_If_Provided()
-            {
-                // Given
-                var fixture = new SqlPackagePublishFixture();
-                fixture.Settings.AzureKeyVaultAuthMethod = AzureKeyVaultAuthMethod.Interactive;
-
-                // When
-                var result = fixture.Run();
-
-                // Then
-                Assert.Equal("/Action:Publish /AzureKeyVaultAuthMethod:Interactive", result.Args);
-            }
-
-            [Fact]
             public void Should_Not_Add_Quiet_If_Not_Provided()
             {
-                // Given
-                var fixture = new SqlPackageExtractFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -211,7 +184,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Source_Connection_String_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -219,14 +191,13 @@ namespace Cake.SqlPackage.UnitTests
                 var result = fixture.Run();
 
                 // Then
-                Assert.Equal("/Action:Extract /SourceConnectionString:\"Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True\"", result.Args);
+                Assert.Equal("/Action:Extract /SourceConnectionString:\"Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True\"",result.Args);
             }
 
             [Fact]
             public void Should_Not_Add_Source_File_If_Source_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -241,7 +212,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Properties_If_Source_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -263,7 +233,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_File_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.SourceFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -277,7 +246,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Connection_If_Source_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.SourceFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -291,7 +259,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Properties_If_Source_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.SourceFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -312,7 +279,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Connection_String_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -327,7 +293,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_File_If_Target_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -342,7 +307,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Properties_If_Target_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -364,7 +328,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Target_File_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -378,7 +341,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Connection_If_Target_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -392,7 +354,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Tenant_Id_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.TenantId = "10";
 
                 // When
@@ -403,24 +364,9 @@ namespace Cake.SqlPackage.UnitTests
             }
 
             [Fact]
-            public void Should_Add_Universal_Authentication_Provided()
-            {
-                // Given
-                var fixture = new SqlPackageImportFixture();
-                fixture.Settings.UniversalAuthentication = true;
-
-                // When
-                var result = fixture.Run();
-
-                // Then
-                Assert.Equal("/Action:Import /UniversalAuthentication:True", result.Args);
-            }
-
-            [Fact]
             public void Should_Not_Add_Target_Properties_If_Target_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -445,7 +391,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Properties_If_Provided(string key, string value)
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.Properties.Add(key, value);
 
                 // When
@@ -459,7 +404,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Properties_After_Settings_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageExtractFixture();
                 fixture.Settings.UniversalAuthentication = true;
                 fixture.Settings.Properties.Add("CommandTimeout", "120");
 
@@ -468,6 +412,20 @@ namespace Cake.SqlPackage.UnitTests
 
                 //Then
                 Assert.Equal($"/Action:Extract /UniversalAuthentication:True /p:CommandTimeout=120", result.Args);
+            }
+
+
+            [Fact]
+            public void Should_Use_Process_Settings_If_Provided()
+            {
+                // Given
+                fixture.ProcessSettings = new ProcessSettings {RedirectStandardOutput = true};
+
+                // When
+                var result = fixture.Run();
+
+                //Then
+                Assert.Equal(fixture.ProcessSettings, result.Process);
             }
         }
     }

--- a/test/Cake.SqlPackage.UnitTests/Import/SqlPackageImportFixture.cs
+++ b/test/Cake.SqlPackage.UnitTests/Import/SqlPackageImportFixture.cs
@@ -11,7 +11,7 @@
         protected override void RunTool()
         {
             var tool = new SqlPackageImportRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Import(Settings);
+            tool.Execute(Settings);
         }
     }
 }

--- a/test/Cake.SqlPackage.UnitTests/Import/SqlPackageImportFixture.cs
+++ b/test/Cake.SqlPackage.UnitTests/Import/SqlPackageImportFixture.cs
@@ -3,15 +3,13 @@
     internal sealed class SqlPackageImportFixture : PackageFixture<SqlPackageImportSettings>
     {
         public SqlPackageImportFixture()
-            : base("SqlPackage.exe")
         {
             Settings.WorkingDirectory = "/Working";
         }
 
-        protected override void RunTool()
+        protected override SqlPackageRunner<SqlPackageImportSettings> CreateTool()
         {
-            var tool = new SqlPackageImportRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Execute(Settings);
+            return new SqlPackageImportRunner(FileSystem, Environment, ProcessRunner, Tools);
         }
     }
 }

--- a/test/Cake.SqlPackage.UnitTests/Import/SqlPackageImportRunnerTests.cs
+++ b/test/Cake.SqlPackage.UnitTests/Import/SqlPackageImportRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Core;
+using Cake.Core.IO;
 using Cake.Testing;
 using Xunit;
 
@@ -9,11 +10,17 @@ namespace Cake.SqlPackage.UnitTests
     {
         public sealed class TheRunMethod
         {
+            private SqlPackageImportFixture fixture;
+
+            public TheRunMethod()
+            {
+                fixture = new SqlPackageImportFixture();
+            }
+
             [Fact]
             public void Should_Throw_If_Settings_Is_Null()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings = null;
 
                 // When
@@ -27,7 +34,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Sql_Package_Runner_Was_Not_Found()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.GivenDefaultToolDoNotExist();
 
                 // When
@@ -44,7 +50,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Use_Sql_Package_Runner_From_Tool_Path_If_Provided(string toolPath, string expected)
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.ToolPath = toolPath;
                 fixture.GivenSettingsToolPathExist();
 
@@ -58,9 +63,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Find_Sql_Package_Runner_If_Tool_Path_Not_Provided()
             {
-                // Given
-                var fixture = new SqlPackageImportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -71,9 +73,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Set_Working_Directory()
             {
-                // Given
-                var fixture = new SqlPackageImportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -85,7 +84,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Process_Was_Not_Started()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.GivenProcessCannotStart();
 
                 // When
@@ -100,7 +98,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.GivenProcessExitsWithCode(1);
 
                 // When
@@ -114,9 +111,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Add_Action_If_Provided()
             {
-                // Given
-                var fixture = new SqlPackageImportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -128,7 +122,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_OutputPath_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.OutputPath = "./artifacts";
 
                 // When
@@ -142,7 +135,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Overwrite_Files_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.OverwriteFiles = true;
 
                 // When
@@ -156,7 +148,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Profile_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.Profile = "./profile.pubxml";
 
                 // When
@@ -170,7 +161,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Quiet_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.Quiet = true;
 
                 // When
@@ -183,9 +173,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Not_Add_Quiet_If_Not_Provided()
             {
-                // Given
-                var fixture = new SqlPackageImportFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -197,7 +184,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Connection_String_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -212,7 +198,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_File_If_Source_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -227,7 +212,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Properties_If_Source_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -249,7 +233,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Source_File_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.SourceFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -263,7 +246,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Properties_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -285,7 +267,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Target_Connection_String_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -300,7 +281,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_File_If_Target_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -315,7 +295,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Properties_If_Target_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -337,7 +316,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_File_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -351,7 +329,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Connection_If_Target_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -365,7 +342,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Tenant_Id_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.TenantId = "10";
 
                 // When
@@ -379,7 +355,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Universal_Authentication_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.UniversalAuthentication = true;
 
                 // When
@@ -393,7 +368,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Properties_If_Target_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -418,7 +392,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Properties_If_Provided(string key, string value)
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.Properties.Add(key, value);
 
                 // When
@@ -432,7 +405,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Properties_After_Settings_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageImportFixture();
                 fixture.Settings.UniversalAuthentication = true;
                 fixture.Settings.Properties.Add("CommandTimeout", "120");
 
@@ -441,6 +413,19 @@ namespace Cake.SqlPackage.UnitTests
 
                 //Then
                 Assert.Equal($"/Action:Import /UniversalAuthentication:True /p:CommandTimeout=120", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Process_Settings_If_Provided()
+            {
+                // Given
+                fixture.ProcessSettings = new ProcessSettings {RedirectStandardOutput = true};
+
+                // When
+                var result = fixture.Run();
+
+                //Then
+                Assert.Equal(fixture.ProcessSettings, result.Process);
             }
         }
     }

--- a/test/Cake.SqlPackage.UnitTests/PackageFixture.cs
+++ b/test/Cake.SqlPackage.UnitTests/PackageFixture.cs
@@ -6,7 +6,9 @@ namespace Cake.SqlPackage.UnitTests
     internal abstract class PackageFixture<TSettings> : ToolFixture<TSettings, ToolFixtureResult>
         where TSettings : SqlPackageSettings, new()
     {
-        protected PackageFixture(string toolName) : base("SqlPackage.exe")
+        public ProcessSettings ProcessSettings { get; set; }
+
+        protected PackageFixture() : base("SqlPackage.exe")
         {
             ProcessRunner.Process.SetStandardOutput(new string[] { });
         }
@@ -15,5 +17,13 @@ namespace Cake.SqlPackage.UnitTests
         {
             return new ToolFixtureResult(path, process);
         }
+
+        /// <summary>Runs the tool.</summary>
+        protected override void RunTool()
+        {
+            CreateTool().Execute(Settings, ProcessSettings);
+        }
+
+        protected abstract SqlPackageRunner<TSettings> CreateTool();
     }
 }

--- a/test/Cake.SqlPackage.UnitTests/Publish/SqlPackagePublishFixture.cs
+++ b/test/Cake.SqlPackage.UnitTests/Publish/SqlPackagePublishFixture.cs
@@ -3,16 +3,13 @@
     internal sealed class SqlPackagePublishFixture : PackageFixture<SqlPackagePublishSettings>
     {
         public SqlPackagePublishFixture()
-            : base("SqlPackage.exe")
         {
             Settings.WorkingDirectory = "/Working";
         }
 
-        /// <summary>Runs the tool.</summary>
-        protected override void RunTool()
+        protected override SqlPackageRunner<SqlPackagePublishSettings> CreateTool()
         {
-            var tool = new SqlPackagePublishRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Execute(Settings);
+            return new SqlPackagePublishRunner(FileSystem, Environment, ProcessRunner, Tools);
         }
     }
 }

--- a/test/Cake.SqlPackage.UnitTests/Publish/SqlPackagePublishFixture.cs
+++ b/test/Cake.SqlPackage.UnitTests/Publish/SqlPackagePublishFixture.cs
@@ -12,7 +12,7 @@
         protected override void RunTool()
         {
             var tool = new SqlPackagePublishRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Publish(Settings);
+            tool.Execute(Settings);
         }
     }
 }

--- a/test/Cake.SqlPackage.UnitTests/Publish/SqlPackagePublishRunnerTests.cs
+++ b/test/Cake.SqlPackage.UnitTests/Publish/SqlPackagePublishRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Core;
+using Cake.Core.IO;
 using Cake.Testing;
 using Xunit;
 
@@ -9,11 +10,17 @@ namespace Cake.SqlPackage.UnitTests
     {
         public sealed class TheRunMethod
         {
+            private SqlPackagePublishFixture fixture;
+
+            public TheRunMethod()
+            {
+                fixture = new SqlPackagePublishFixture();
+            }
+
             [Fact]
             public void Should_Throw_If_Settings_Is_Null()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings = null;
 
                 // When
@@ -27,7 +34,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Sql_Package_Runner_Was_Not_Found()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.GivenDefaultToolDoNotExist();
 
                 // When
@@ -44,7 +50,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Use_Sql_Package_Runner_From_Tool_Path_If_Provided(string toolPath, string expected)
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.ToolPath = toolPath;
                 fixture.GivenSettingsToolPathExist();
 
@@ -58,9 +63,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Find_Sql_Package_Runner_If_Tool_Path_Not_Provided()
             {
-                // Given
-                var fixture = new SqlPackagePublishFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -71,9 +73,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Set_Working_Directory()
             {
-                // Given
-                var fixture = new SqlPackagePublishFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -85,7 +84,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Process_Was_Not_Started()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.GivenProcessCannotStart();
 
                 // When
@@ -100,7 +98,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.GivenProcessExitsWithCode(1);
 
                 // When
@@ -114,9 +111,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Add_Action_If_Provided()
             {
-                // Given
-                var fixture = new SqlPackagePublishFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -128,7 +122,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Azure_Key_Vault_Auth_Method_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.AzureKeyVaultAuthMethod = AzureKeyVaultAuthMethod.Interactive;
 
                 // When
@@ -142,7 +135,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Secret_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.AzureSecret = "banana";
 
                 // When
@@ -156,7 +148,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_OutputPath_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.OutputPath = "./artifacts";
 
                 // When
@@ -170,7 +161,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Overwrite_Files_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.OverwriteFiles = true;
 
                 // When
@@ -184,7 +174,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Profile_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.Profile = "./profile.pubxml";
 
                 // When
@@ -198,7 +187,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Quiet_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.Quiet = true;
 
                 // When
@@ -211,9 +199,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Not_Add_Quiet_If_Not_Provided()
             {
-                // Given
-                var fixture = new SqlPackagePublishFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -225,7 +210,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Source_Connection_String_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -240,7 +224,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_File_If_Source_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -255,7 +238,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Properties_If_Source_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -277,7 +259,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Source_File_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.SourceFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -291,7 +272,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Connection_If_Source_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.SourceFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -305,7 +285,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Properties_If_Source_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.SourceFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -326,7 +305,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Target_Connection_String_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -341,7 +319,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_File_If_Target_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -356,7 +333,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Properties_If_Target_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -378,7 +354,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Target_File_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -392,7 +367,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Connection_If_Target_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -406,7 +380,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Properties_If_Target_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -423,20 +396,6 @@ namespace Cake.SqlPackage.UnitTests
                 Assert.DoesNotContain("/TargetUser:", result.Args);
             }
 
-            [Fact]
-            public void Should_Add_Tenant_Id_Provided()
-            {
-                // Given
-                var fixture = new SqlPackageExportFixture();
-                fixture.Settings.TenantId = "10";
-
-                // When
-                var result = fixture.Run();
-
-                // Then
-                Assert.Equal("/Action:Export /TenantId:10", result.Args);
-            }
-
             [Theory]
             [InlineData("CommandTimeout", "120")]
             [InlineData("CreateNewDatabase", "True")]
@@ -445,7 +404,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Properties_If_Provided(string key, string value)
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.Properties.Add(key, value);
 
                 // When
@@ -459,7 +417,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Properties_After_Settings_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.OverwriteFiles = true;
                 fixture.Settings.Properties.Add("CommandTimeout", "120");
 
@@ -478,7 +435,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Variables_If_Provided(string key, string value)
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.Variables.Add(key, value);
 
                 // When
@@ -492,7 +448,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Variables_After_Settings_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackagePublishFixture();
                 fixture.Settings.OverwriteFiles = true;
                 fixture.Settings.Variables.Add("CommandTimeout", "120");
 
@@ -501,6 +456,19 @@ namespace Cake.SqlPackage.UnitTests
 
                 //Then
                 Assert.Equal($"/Action:Publish /OverwriteFiles:True /v:CommandTimeout=120", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Process_Settings_If_Provided()
+            {
+                // Given
+                fixture.ProcessSettings = new ProcessSettings {RedirectStandardOutput = true};
+
+                // When
+                var result = fixture.Run();
+
+                //Then
+                Assert.Equal(fixture.ProcessSettings, result.Process);
             }
         }
     }

--- a/test/Cake.SqlPackage.UnitTests/Script/SqlPackageScriptFixture.cs
+++ b/test/Cake.SqlPackage.UnitTests/Script/SqlPackageScriptFixture.cs
@@ -12,7 +12,7 @@
         protected override void RunTool()
         {
             var tool = new SqlPackageScriptRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Script(Settings);
+            tool.Execute(Settings);
         }
     }
 }

--- a/test/Cake.SqlPackage.UnitTests/Script/SqlPackageScriptFixture.cs
+++ b/test/Cake.SqlPackage.UnitTests/Script/SqlPackageScriptFixture.cs
@@ -3,16 +3,13 @@
     internal sealed class SqlPackageScriptFixture : PackageFixture<SqlPackageScriptSettings>
     {
         public SqlPackageScriptFixture()
-            : base("SqlPackage.exe")
         {
             Settings.WorkingDirectory = "/Working";
         }
 
-        /// <summary>Runs the tool.</summary>
-        protected override void RunTool()
+        protected override SqlPackageRunner<SqlPackageScriptSettings> CreateTool()
         {
-            var tool = new SqlPackageScriptRunner(FileSystem, Environment, ProcessRunner, Tools);
-            tool.Execute(Settings);
+            return new SqlPackageScriptRunner(FileSystem, Environment, ProcessRunner, Tools);
         }
     }
 }

--- a/test/Cake.SqlPackage.UnitTests/Script/SqlPackageScriptRunnerTests.cs
+++ b/test/Cake.SqlPackage.UnitTests/Script/SqlPackageScriptRunnerTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Cake.Core;
+using Cake.Core.IO;
 using Cake.Testing;
 using Xunit;
 
@@ -9,11 +10,17 @@ namespace Cake.SqlPackage.UnitTests
     {
         public sealed class TheRunMethod
         {
+            private SqlPackageScriptFixture fixture;
+
+            public TheRunMethod()
+            {
+                fixture = new SqlPackageScriptFixture();
+            }
+
             [Fact]
             public void Should_Throw_If_Settings_Is_Null()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings = null;
 
                 // When
@@ -27,7 +34,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Sql_Package_Runner_Was_Not_Found()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.GivenDefaultToolDoNotExist();
 
                 // When
@@ -44,7 +50,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Use_Sql_Package_Runner_From_Tool_Path_If_Provided(string toolPath, string expected)
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.ToolPath = toolPath;
                 fixture.GivenSettingsToolPathExist();
 
@@ -58,9 +63,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Find_Sql_Package_Runner_If_Tool_Path_Not_Provided()
             {
-                // Given
-                var fixture = new SqlPackageScriptFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -71,9 +73,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Set_Working_Directory()
             {
-                // Given
-                var fixture = new SqlPackageScriptFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -85,7 +84,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Process_Was_Not_Started()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.GivenProcessCannotStart();
 
                 // When
@@ -100,7 +98,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Throw_If_Process_Has_A_Non_Zero_Exit_Code()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.GivenProcessExitsWithCode(1);
 
                 // When
@@ -114,9 +111,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Add_Action_If_Provided()
             {
-                // Given
-                var fixture = new SqlPackageScriptFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -128,7 +122,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_OutputPath_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.OutputPath = "./artifacts";
 
                 // When
@@ -142,7 +135,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Overwrite_Files_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.OverwriteFiles = true;
 
                 // When
@@ -156,7 +148,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Profile_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.Profile = "./profile.pubxml";
 
                 // When
@@ -170,7 +161,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Quiet_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.Quiet = true;
 
                 // When
@@ -183,9 +173,6 @@ namespace Cake.SqlPackage.UnitTests
             [Fact]
             public void Should_Not_Add_Quiet_If_Not_Provided()
             {
-                // Given
-                var fixture = new SqlPackageScriptFixture();
-
                 // When
                 var result = fixture.Run();
 
@@ -197,7 +184,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Source_Connection_String_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -212,7 +198,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_File_If_Source_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -227,7 +212,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Properties_If_Source_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.SourceConnectionString =
                     "Data Source=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -249,7 +233,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Source_File_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.SourceFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -263,7 +246,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Connection_If_Source_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.SourceFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -277,7 +259,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Source_Properties_If_Source_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.SourceFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -298,7 +279,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Target_Connection_String_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -313,7 +293,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_File_If_Target_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -328,7 +307,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Properties_If_Target_Connection_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.TargetConnectionString =
                     "Data Target=(LocalDB)\\v11.0;AttachDbFileName=|DataDirectory|\\DatabaseFileName.mdf;InitialCatalog=DatabaseName;Integrated Security=True;MultipleActiveResultSets=True";
 
@@ -350,7 +328,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Target_File_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -364,7 +341,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Target_Connection_If_Target_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -378,7 +354,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Not_Add_Most_Target_Properties_If_Target_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
 
                 // When
@@ -398,7 +373,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Still_Add_TargetDatabaseName_If_Target_File_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.TargetFile = "./sqlpublishprofile.pubxml";
                 fixture.Settings.TargetDatabaseName = "mongoose";
 
@@ -409,20 +383,6 @@ namespace Cake.SqlPackage.UnitTests
                 Assert.Contains("/TargetDatabaseName:mongoose", result.Args);
             }
 
-            [Fact]
-            public void Should_Add_Tenant_Id_Provided()
-            {
-                // Given
-                var fixture = new SqlPackageExportFixture();
-                fixture.Settings.TenantId = "10";
-
-                // When
-                var result = fixture.Run();
-
-                // Then
-                Assert.Equal("/Action:Export /TenantId:10", result.Args);
-            }
-
             [Theory]
             [InlineData("CommandTimeout", "120")]
             [InlineData("CreateNewDatabase", "True")]
@@ -431,7 +391,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Properties_If_Provided(string key, string value)
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.Properties.Add(key, value);
 
                 // When
@@ -445,7 +404,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Properties_After_Settings_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.OverwriteFiles = true;
                 fixture.Settings.Properties.Add("CommandTimeout", "120");
 
@@ -464,7 +422,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Variables_If_Provided(string key, string value)
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.Variables.Add(key, value);
 
                 // When
@@ -478,7 +435,6 @@ namespace Cake.SqlPackage.UnitTests
             public void Should_Add_Variables_After_Settings_If_Provided()
             {
                 // Given
-                var fixture = new SqlPackageScriptFixture();
                 fixture.Settings.OverwriteFiles = true;
                 fixture.Settings.Variables.Add("CommandTimeout", "120");
 
@@ -487,6 +443,19 @@ namespace Cake.SqlPackage.UnitTests
 
                 //Then
                 Assert.Equal($"/Action:Script /OverwriteFiles:True /v:CommandTimeout=120", result.Args);
+            }
+
+            [Fact]
+            public void Should_Use_Process_Settings_If_Provided()
+            {
+                // Given
+                fixture.ProcessSettings = new ProcessSettings {RedirectStandardOutput = true};
+
+                // When
+                var result = fixture.Run();
+
+                //Then
+                Assert.Equal(fixture.ProcessSettings, result.Process);
             }
         }
     }

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="Cake" version="0.22.2" />
+	<package id="Cake" version="0.32.1" />
 </packages>


### PR DESCRIPTION
My team is currently using the `SqlPackagePublish` method to initialize our integration test databases. This works great, but because our database schema is extremely large, it results in a lot of noise in our build logs. And because the `Quiet` option on `SqlPackage.exe` doesn't actually work, there's not currently a good way to disable this output. This PR makes it possible to suppress this standard output via `ProcessSettings.RedirectStandardOutput`, and also provides the ability to make any other tweaks a user would like by providing `ProcessSettings` to the Cake alias methods.

As I was making the change, I also tried to DRY some things up by creating a base `Execute` method on `SqlPackageRunner`, since all of the `DeployReport`/`DriftReport`/etc. methods were identical. I also created setup logic for the test classes, and removed a couple stray tests that appeared to have drifted into the wrong test classes (e.g. https://github.com/northwoodspd/Cake.SqlPackage/commit/ad2fb65e462cea76898f2354d49f558befc9e4b3#diff-066d048ee3f063a68f097fbbce6dfab5L413).

Lastly, to get the package to build, I ended up having to bump the version of Cake. I tried going back to an old version of Cake.Recipe, but I couldn't find one available that was compatible with the pinned version of Cake.

Thanks for your work on this library. We've found it very helpful, and hoped this PR could help make it even a tiny bit more for useful for others.